### PR TITLE
make Fontist and Formula cards open in same tab, not new tab

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,10 +7,12 @@ features:
   - title: 📄 Fontist
     details: 👩‍💻 Install openly-licensed fonts on Windows, Linux and Mac!
     link: https://fontist.org/fontist/
+    target: _self
     linkText: Go to Fontist
   - title: 📦 Formulas
     details: 🔎 Searchable index of all installable Fontist Formulas
     link: https://fontist.org/formulas/
+    target: _self
     linkText: Go to Formulas
 ---
 


### PR DESCRIPTION
use `<a href='...' target=_self>` so that the link doesn't open in a new tab. vitepress default opens things in new tab if they aren't vitepress same-site pages.

https://vitepress.dev/guide/routing#linking-to-non-vitepress-pages
https://vitepress.dev/reference/default-theme-home-page#features-section
```ts
interface Feature {
  // Show icon on each feature box.
  icon?: FeatureIcon

  // Title of the feature.
  title: string

  // Details of the feature.
  details: string

  // Link when clicked on feature component. The link can
  // be both internal or external.
  //
  // e.g. `guide/reference/default-theme-home-page` or `https://example.com`
  link?: string

  // Link text to be shown inside feature component. Best
  // used with `link` option.
  //
  // e.g. `Learn more`, `Visit page`, etc.
  linkText?: string

  // Link rel attribute for the `link` option.
  //
  // e.g. `external`
  rel?: string

  // Link target attribute for the `link` option.
  target?: string // 🛑🛑🛑🛑🛑🛑
}
```